### PR TITLE
Signature at message start

### DIFF
--- a/src/esmska/data/Config.java
+++ b/src/esmska/data/Config.java
@@ -24,7 +24,7 @@ public class Config extends Object implements Serializable {
     /** mutex whether config already loaded from disk */
     private static boolean loaded = false;
     
-    private static final String LATEST_VERSION = "1.6";
+    private static final String LATEST_VERSION = "1.6.99";
     private static final Logger logger = Logger.getLogger(Config.class.getName());
 
     private String version = "";

--- a/src/esmska/data/Envelope.java
+++ b/src/esmska/data/Envelope.java
@@ -77,6 +77,21 @@ public class Envelope {
         return min;
     }
     
+    /** How many characters at the message start are occupied by the prefix
+     * (i.e. sender name)
+     */
+    public int getPrefixLength() {
+        int max = 0;
+        for (Contact c : contacts) {
+            Gateway gateway = gateways.get(c.getGateway());
+            if (gateway == null) {
+                continue;
+            }
+            max = Math.max(max, gateway.getSenderName().length());
+        }
+        return max;
+    }
+    
     /** get length of one sms
      * @return length of one sms or -1 when sms length is unspecified
      */
@@ -143,10 +158,10 @@ public class Envelope {
             String msgText = text;
             // add user signature to the message
             if (gateway != null) {
-                String signature = gateway.getSenderNameSuffix();
+                String signature = gateway.getSenderName();
                 // only if signature is not already added
-                if (!msgText.trim().toLowerCase().endsWith(signature.trim().toLowerCase())) {
-                    msgText += signature;
+                if (!msgText.trim().toLowerCase().startsWith(signature.trim().toLowerCase())) {
+                    msgText = signature + msgText;
                 }
             }
             String messageId = SMS.generateID();

--- a/src/esmska/data/Gateway.java
+++ b/src/esmska/data/Gateway.java
@@ -161,13 +161,13 @@ public class Gateway implements GatewayInfo, Comparable<Gateway> {
         this.config = config;
     }
     
-    /** Get sender name signature suffix that should be appended to the message
+    /** Get sender name signature that should be prepended to the message
      * before it is sent.
-     * @return empty string if gateway appends the name signature automatically
-     *  or user does not want any signature to be appended; otherwise user name 
-     *  signature prepended with a newline character
+     * @return empty string if gateway adds the name signature automatically
+     *  or user does not want any signature to be added; otherwise user name 
+     *  signature
      */
-    public String getSenderNameSuffix() {
+    public String getSenderName() {
         if (hasFeature(Feature.SENDER_NAME)) {
             // gateway will append sender name signature automatically
             return "";
@@ -181,13 +181,12 @@ public class Gateway implements GatewayInfo, Comparable<Gateway> {
         }
         
         // user wants to append his name signature
-        // prepend it with a single space to separate it from text content
-        String suffix = "\n" + signature.getUserName();
+        String result = signature.getUserName();
         // remove accents if required
         if (Config.getInstance().isRemoveAccents()) {
-            suffix = MiscUtils.removeAccents(suffix);
+            result = MiscUtils.removeAccents(result);
         }
-        return suffix;
+        return result;
     }
 
     @Override
@@ -278,8 +277,8 @@ public class Gateway implements GatewayInfo, Comparable<Gateway> {
             // gateway will append its own string
             return signatureExtraLength;
         } else {
-            // we will append a newline character before the sender name
-            return 1;
+            // we will not insert anything between signature and message
+            return 0;
         }
     }
 

--- a/src/esmska/gui/ConfigFrame.form
+++ b/src/esmska/gui/ConfigFrame.form
@@ -18,8 +18,8 @@
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
   </SyntheticProperties>
   <Events>
-    <EventHandler event="windowGainedFocus" listener="java.awt.event.WindowFocusListener" parameters="java.awt.event.WindowEvent" handler="formWindowGainedFocus"/>
     <EventHandler event="windowClosing" listener="java.awt.event.WindowListener" parameters="java.awt.event.WindowEvent" handler="formWindowClosing"/>
+    <EventHandler event="componentShown" listener="java.awt.event.ComponentListener" parameters="java.awt.event.ComponentEvent" handler="formComponentShown"/>
   </Events>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="1"/>
@@ -739,6 +739,11 @@
                       <ResourceString bundle="esmska/resources/l10n.properties" key="ConfigFrame.senderNameTextField.toolTipText" replaceFormat="l10n.getString(&quot;{key}&quot;)"/>
                     </Property>
                   </Properties>
+                  <Events>
+                    <EventHandler event="focusGained" listener="java.awt.event.FocusListener" parameters="java.awt.event.FocusEvent" handler="senderNameTextFieldFocusGained"/>
+                    <EventHandler event="focusLost" listener="java.awt.event.FocusListener" parameters="java.awt.event.FocusEvent" handler="senderNameTextFieldFocusLost"/>
+                    <EventHandler event="keyTyped" listener="java.awt.event.KeyListener" parameters="java.awt.event.KeyEvent" handler="senderNameTextFieldKeyTyped"/>
+                  </Events>
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="demandDeliveryReportCheckBox">
                   <Properties>

--- a/src/esmska/gui/ConfigFrame.java
+++ b/src/esmska/gui/ConfigFrame.java
@@ -24,7 +24,6 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.awt.event.WindowFocusListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.logging.Level;
@@ -69,6 +68,10 @@ import esmska.utils.RuntimeUtils;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Toolkit;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
@@ -82,8 +85,11 @@ import javax.swing.DefaultListCellRenderer;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.swing.JToolTip;
 import javax.swing.KeyStroke;
 import javax.swing.ListCellRenderer;
+import javax.swing.Popup;
+import javax.swing.PopupFactory;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingUtilities;
 import javax.swing.border.TitledBorder;
@@ -122,6 +128,10 @@ public class ConfigFrame extends javax.swing.JFrame {
         GENERAL, APPEARANCE, GATEWAYS, PRIVACY, CONNECTION
     }
 
+    private enum UpdateType {
+        SHOW, UPDATE, HIDE
+    }
+    
     /** Creates new form ConfigFrame */
     public ConfigFrame() {
         initComponents();
@@ -205,6 +215,12 @@ public class ConfigFrame extends javax.swing.JFrame {
             @Override
             public void onUpdate(DocumentEvent e) {
                 updateSenderNumberWarnLabel();
+            }
+        });
+        senderNameTextField.getDocument().addDocumentListener(new AbstractDocumentListener() {
+            @Override
+            public void onUpdate(DocumentEvent e) {
+                updateSenderNamePopup(UpdateType.UPDATE);
             }
         });
         DocumentListener keyringListener = new AbstractDocumentListener() {
@@ -371,6 +387,37 @@ public class ConfigFrame extends javax.swing.JFrame {
         }
     }
 
+    /** Update the text in senderNamePopup and its visibility */
+    private void updateSenderNamePopup(UpdateType updateType) {
+        if (senderNamePopup != null) {
+            senderNamePopup.hide();
+        }
+        
+        if (updateType == UpdateType.SHOW ||
+                (updateType == UpdateType.UPDATE && senderNamePopup != null)) {
+            String name = senderNameTextField.getText();
+            JToolTip toolTip = new JToolTip();
+            toolTip.setTipText(MessageFormat.format(
+                    l10n.getString("ConfigFrame.senderNamePopup.exampleText"),
+                    name));
+            toolTip.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    if (senderNamePopup != null) {
+                        senderNamePopup.hide();
+                    }
+                }
+            });
+            int x = senderNameLabel.getLocationOnScreen().x + senderNameTextField.getHeight() / 2;
+            int y = senderNameTextField.getLocationOnScreen().y + senderNameTextField.getHeight() - 2;
+            senderNamePopup = PopupFactory.getSharedInstance().getPopup(
+                    senderNameTextField, toolTip, x, y);
+            senderNamePopup.show();
+        } else {
+            senderNamePopup = null;
+        }
+    }
+    
     /** Save all properties of the currently selected signature. */
     private void updateSignature() {
         if (!fullyInicialized) {
@@ -466,19 +513,18 @@ public class ConfigFrame extends javax.swing.JFrame {
 
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setTitle(l10n.getString("ConfigFrame.title")); // NOI18N
-        addWindowFocusListener(new WindowFocusListener() {
-            public void windowGainedFocus(WindowEvent evt) {
-                formWindowGainedFocus(evt);
-            }
-            public void windowLostFocus(WindowEvent evt) {
-            }
-        });
         addWindowListener(new WindowAdapter() {
             public void windowClosing(WindowEvent evt) {
                 formWindowClosing(evt);
             }
         });
         Mnemonics.setLocalizedText(removeAccentsCheckBox, l10n.getString("ConfigFrame.removeAccentsCheckBox.text"));
+        addComponentListener(new ComponentAdapter() {
+            public void componentShown(ComponentEvent evt) {
+                formComponentShown(evt);
+            }
+        });
+
         removeAccentsCheckBox.setToolTipText(l10n.getString("ConfigFrame.removeAccentsCheckBox.toolTipText")); // NOI18N
 
         Binding binding = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, config, ELProperty.create("${removeAccents}"), removeAccentsCheckBox, BeanProperty.create("selected"));
@@ -767,6 +813,20 @@ public class ConfigFrame extends javax.swing.JFrame {
     senderNameTextField.setColumns(12);
     senderNameTextField.setToolTipText(l10n.getString("ConfigFrame.senderNameTextField.toolTipText")); // NOI18N
     Mnemonics.setLocalizedText(demandDeliveryReportCheckBox, l10n.getString("ConfigFrame.demandDeliveryReportCheckBox.text"));
+    senderNameTextField.addFocusListener(new FocusAdapter() {
+        public void focusGained(FocusEvent evt) {
+            senderNameTextFieldFocusGained(evt);
+        }
+        public void focusLost(FocusEvent evt) {
+            senderNameTextFieldFocusLost(evt);
+        }
+    });
+    senderNameTextField.addKeyListener(new KeyAdapter() {
+        public void keyTyped(KeyEvent evt) {
+            senderNameTextFieldKeyTyped(evt);
+        }
+    });
+
     demandDeliveryReportCheckBox.setToolTipText(l10n.getString("ConfigFrame.demandDeliveryReportCheckBox.toolTipText")); // NOI18N
     demandDeliveryReportCheckBox.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent evt) {
@@ -1302,9 +1362,9 @@ private void formWindowClosing(WindowEvent evt) {//GEN-FIRST:event_formWindowClo
     }
 }//GEN-LAST:event_formWindowClosing
 
-private void formWindowGainedFocus(WindowEvent evt) {//GEN-FIRST:event_formWindowGainedFocus
+private void formComponentShown(ComponentEvent evt) {//GEN-FIRST:event_formComponentShown
     closeButton.requestFocusInWindow();
-}//GEN-LAST:event_formWindowGainedFocus
+}//GEN-LAST:event_formComponentShown
 
 private void signatureComboBoxActionPerformed(ActionEvent evt) {//GEN-FIRST:event_signatureComboBoxActionPerformed
     boolean oldInit = fullyInicialized;
@@ -1378,6 +1438,31 @@ private void demandDeliveryReportCheckBoxActionPerformed(ActionEvent evt) {//GEN
     Gateway gateway = gwTableModel.getGateway(row);
     gateway.getConfig().setReceipt(demandDeliveryReportCheckBox.isSelected());
 }//GEN-LAST:event_demandDeliveryReportCheckBoxActionPerformed
+
+    private void senderNameTextFieldFocusGained(FocusEvent evt) {//GEN-FIRST:event_senderNameTextFieldFocusGained
+        updateSenderNamePopup(UpdateType.SHOW);
+    }//GEN-LAST:event_senderNameTextFieldFocusGained
+
+    private void senderNameTextFieldFocusLost(FocusEvent evt) {//GEN-FIRST:event_senderNameTextFieldFocusLost
+        updateSenderNamePopup(UpdateType.HIDE);
+    }//GEN-LAST:event_senderNameTextFieldFocusLost
+
+    /** Adds a colon to the end of senderNameTextField
+     * if the first characted has just been typed. */
+    private void senderNameTextFieldKeyTyped(KeyEvent evt) {//GEN-FIRST:event_senderNameTextFieldKeyTyped
+        char c = evt.getKeyChar();
+        if (c < ' ' || c == KeyEvent.CHAR_UNDEFINED) return;
+        if (senderNameTextField.getText().length() != 0) return;
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                if (senderNameTextField.getText().length() == 0) return;
+                String typed = senderNameTextField.getText();
+                senderNameTextField.setText(typed + ":");
+                senderNameTextField.setCaretPosition(typed.length());
+            }
+        });
+    }//GEN-LAST:event_senderNameTextFieldKeyTyped
     
     private class LaFComboRenderer extends DefaultListCellRenderer {
         private final ListCellRenderer lafRenderer = new JList().getCellRenderer();
@@ -1730,4 +1815,5 @@ private void demandDeliveryReportCheckBoxActionPerformed(ActionEvent evt) {//GEN
     private BindingGroup bindingGroup;
     // End of variables declaration//GEN-END:variables
     
+    private Popup senderNamePopup;
 }

--- a/src/esmska/resources/l10n.properties
+++ b/src/esmska/resources/l10n.properties
@@ -497,3 +497,4 @@ GatewayProblem.WRONG_NUMBER.help=The recipient number is either not supported by
 GatewayProblem.WRONG_SIGNATURE.help=The sender number or the sender name is in wrong format (maybe the number is not in an international format?). Visit <a href="{0}">the gateway configuration</a> and fix the problem, then try to send the message again. If problems persist, visit <a href="{1}">{1}</a> and find out why the gateway keeps rejecting your signature.
 GatewayErrorMessage.retryButton.text=&Send again
 GatewayErrorMessage.retryButton.toolTipText=<html>Please note that this button will unpause your SMS queue.<br>\nThat means that more messages might be re-sent, not just this one.</html>
+ConfigFrame.senderNamePopup.exampleText=Result: {0}Message text

--- a/src/esmska/update/LegacyUpdater.java
+++ b/src/esmska/update/LegacyUpdater.java
@@ -1,6 +1,7 @@
 package esmska.update;
 
 import com.csvreader.CsvReader;
+import esmska.Context;
 import esmska.data.Config;
 import esmska.data.CountryPrefix;
 import esmska.data.Keyring;
@@ -147,6 +148,22 @@ public class LegacyUpdater {
             if (StringUtils.isNotEmpty(senderNumber)) {
                 defaultSig.setUserNumber(senderNumber);
             }
+        }
+        
+        //changes to 1.7: Append a colon to signatures
+        if (Config.compareProgramVersions(version, "1.6") <= 0) {
+            Context.persistenceManager.loadGateways();
+            Context.persistenceManager.loadGatewayProperties();
+            ArrayList<Signature> sigList = new ArrayList<Signature>();
+            sigList.addAll(Signatures.getInstance().getAll());
+            sigList.addAll(Signatures.getInstance().getSpecial());
+            for (Signature signature : sigList) {
+                String userName = signature.getUserName();
+                if (StringUtils.isNotEmpty(userName)) {
+                    signature.setUserName(userName + ":");
+                }
+            }
+            Context.persistenceManager.saveGatewayProperties();
         }
     }
 }


### PR DESCRIPTION
- This modification puts the signature (i.e. sender name) at the message start.
- Any separators have to be contained in the signature.
- While the sender name field in signature configuration has focus, a tooltip with an example result of prepending the signature to the message is displayed.
- After the first character has been typed into the sender name field, a colon is added to the right of the caret.
- Message size indicators and message part coloring are modified accordingly.
- The signature is prepended only if it is not already present at the message text start. Only whitespace is stripped for the purpose of comparison to allow signatures composed entirely of non-alphanumeric characters.
- Automatic upgrade appends a colon to all non-empty signatures.
- One localization string for translation has been added.
